### PR TITLE
Fix Azerbaijão wording in pt-BR

### DIFF
--- a/lib/countries/data/translations/countries-pt_BR.yaml
+++ b/lib/countries/data/translations/countries-pt_BR.yaml
@@ -18,7 +18,7 @@ AT: Áustria
 AU: Austrália
 AW: Aruba
 AX: Ilhas Åland
-AZ: Azerbaidjão
+AZ: Azerbaijão
 BA: Bósnia-Herzegóvina
 BB: Barbados
 BD: Bangladesh


### PR DESCRIPTION
We prefer the wording Azerbaijão to refer to Azerbaijan

This can be verified by:
1. Searching through pt-br google which corrects us to use `Azerbaijão` instead of `Azerbaidjão`
<img width="733" alt="image" src="https://github.com/duduribeiro/countries/assets/771411/3bced3a1-08f2-4e97-b4d1-5876a58c7012">

2. The Brazilian Central Bank also uses `Azerbaijão` word:
https://www.bcb.gov.br/ftp/paises.txt code: `00736` or https://www.bcb.gov.br/acessoinformacao/legado?url=https:%2F%2Fwww.bcb.gov.br%2Frex%2FCenso2000%2Fport%2Fmanual%2Fpais.asp%3Fidpai%3Dcenso2000inf 
<img width="167" alt="image" src="https://github.com/duduribeiro/countries/assets/771411/32d88aac-b579-4ba7-966a-82ea07d6fc56">

3. Or, my preferred, on Brazil F1 🏎️  we call it Grand Prix of `Azerbaijão` 😄 
<img width="430" alt="image" src="https://github.com/duduribeiro/countries/assets/771411/ad19f8af-09af-42de-a23d-b6b8151fc3bb">



